### PR TITLE
JCenter linking params

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,4 +59,11 @@ publish {
     groupId = "ktlint"
     groupName = "Ktlint"
     artifact = "reporter"
+    gitUrl = "https://github.com/AlgirdasPundzius/ktlint-codequality"
+    licenses {
+        license {
+            name = "MIT"
+            url = "https://opensource.org/licenses/MIT"
+        }
+    }
 }


### PR DESCRIPTION
Update `build.gradle.kts` for allow JCenter linking